### PR TITLE
Chatcolab btn light, layout, di images, target

### DIFF
--- a/_includes/collection-banner.html
+++ b/_includes/collection-banner.html
@@ -34,7 +34,7 @@
             {% if site.data.theme.tagline %}<p>{{ site.data.theme.tagline }}</p>{% endif %}
         </div>
         <div class="col-md-3 d-none d-md-block text-right">
-            <button type="button" class="btn btn-light border-secondary" data-toggle="modal" data-target="#collections">
+            <button type="button" class="btn border-secondary" data-toggle="modal" data-target="#collections">
             <img class="img-fluid" src="https://www.lib.uidaho.edu/media/digital/justdi_logo_sm.png" title="University of Idaho Library Digital Initiatives" alt="digital initiatives logo" ></button>
         </div>
     </div>

--- a/_includes/collection-banner.html
+++ b/_includes/collection-banner.html
@@ -12,19 +12,21 @@
 }
 </style>
 <div id="home-banner" class="jumbotron jumbotron-fluid mb-0 p-0" aria-label="{{ site.data.theme.home-banner-image-title }}">
+
     <div class="container">
         <div class="row justify-content-center">
             <div id="home-title-box" class="col-12">
                 <div class="text-dark title-card p-2 rounded text-center">
+                       <a class="text-info d-none d-md-block" href="https://www.lib.uidaho.edu/digital"><img src="https://www.lib.uidaho.edu/media/digital/justdi_logo_sm.png" class="p-1 " alt="digital initiatives logo" ></a>
                     <h1 class="display-4">{{ site.data.theme.title }}</h1>
                     {% if site.data.theme.tagline %}<p>{{ site.data.theme.tagline }}</p>{% endif %}
                     <a title="University of Idaho Library Digital Initiatives" href="https://www.lib.uidaho.edu/digital">
-                    <img src="https://www.lib.uidaho.edu/media/digital/justdi_logo_sm.png" class="p-1 pb-3" alt="digital initiatives logo" ></a>
+                    
                 </div>
             </div>
         </div>
     </div>
-    <div class="text-right p-1"><small><a class="text-info" href="{% if site.data.theme.home-banner-image-number %}{{ site.data.theme.home-banner-image-number | prepend: site.data.theme.metadata | prepend: '/items/' | prepend: site.baseurl | append: '.html' }}{% else %}{{ site.data.theme.home-banner-image-link }}{% endif %}">Featured Image</a></small></div>
+    <div class="text-right p-1"><small><a style="background:rgb(0,0,0,.5);padding:.5em" class="text-info" href="{% if site.data.theme.home-banner-image-number %}{{ site.data.theme.home-banner-image-number | prepend: site.data.theme.metadata | prepend: '/items/' | prepend: site.baseurl | append: '.html' }}{% else %}{{ site.data.theme.home-banner-image-link }}{% endif %}">Featured Image</a></small></div>
 </div>
 {%- else -%}
 <div class="container">
@@ -34,7 +36,7 @@
             {% if site.data.theme.tagline %}<p>{{ site.data.theme.tagline }}</p>{% endif %}
         </div>
         <div class="col-md-3 d-none d-md-block text-right">
-            <button type="button" class="btn border-secondary" data-toggle="modal" data-target="#collections">
+            <button type="button" class="btn btn-outline-light" data-toggle="modal" data-target="#collections">
             <img class="img-fluid" src="https://www.lib.uidaho.edu/media/digital/justdi_logo_sm.png" title="University of Idaho Library Digital Initiatives" alt="digital initiatives logo" ></button>
         </div>
     </div>

--- a/_includes/collection-nav.html
+++ b/_includes/collection-nav.html
@@ -4,9 +4,9 @@
             <span class="navbar-toggler-icon"></span>
         </button>
 
-        <div class="d-md-none float-right">
-            <button type="button" class="btn btn p-1" data-toggle="modal" data-target="#collections">
-            <img class="img-fluid" src="https://www.lib.uidaho.edu/media/digital/bannerlogo_allwhite.png" title="University of Idaho Library Digital Initiatives" alt="digital initiatives logo" ></button>
+        <div class="d-md-none float-right col-8">
+            <button type="button" class="btn btn p-1  float-right" data-toggle="modal" data-target="#collections">
+            <img class="img-fluid float-right" id="mobile-nav-image" src="https://www.lib.uidaho.edu/media/digital/bannerlogo_allwhite.png" title="University of Idaho Library Digital Initiatives" alt="digital initiatives logo" ></button>
         </div>
 
         <div class="collapse navbar-collapse" id="page-nav">

--- a/_includes/foot.html
+++ b/_includes/foot.html
@@ -3,7 +3,7 @@
 <script src="{{ '/js/bootstrap.bundle.min.js' | prepend: site.digital-assets }}"></script>
 <!-- load other js -->
 {% if page.layout == "browse" %}{% include js/browse-js.html %}
-<script defer src="{{ '/fontawesome/js/all.min.js' | prepend: site.digital-assets }}"></script>{% endif %}
+{% endif %}
 {% if page.layout == "data" %}{% include js/table-js.html %}{% endif %}
 {% if page.layout == "subjects" %}{% include js/subjects-js.html %}{% endif %}
 {% if page.layout == "locations" %}{% include js/locations-js.html %}{% endif %}
@@ -11,5 +11,6 @@
 {% if page.layout == "map" %}{% include js/map-js.html %}{% endif %}
 {% if layout.gallery == true %}{% include js/gallery-js.html %}{% endif %}
 {% if page.layout == "home-infographic" %}{% include js/carousel-js.html %}
-<script defer src="{{ '/fontawesome/js/all.min.js' | prepend: site.digital-assets }}"></script>{% endif %}
+{% endif %}
 {% if page.layout == "item" %}{% include js/arrow-page-control-js.html %}{% endif %}
+<script defer src="{{ '/fontawesome/js/all.min.js' | prepend: site.digital-assets }}"></script>

--- a/_includes/js/map-js.html
+++ b/_includes/js/map-js.html
@@ -52,10 +52,10 @@ if(window.location.hash) {
         pointToLayer: function(feature,latlng){
             var marker = L.marker(latlng);
             marker.bindPopup('<h3>' + feature.properties.title + 
-            '</h3><p><a target="_blank" class="btn btn-light" href="{% if site.data.theme.repo-link %}{{ site.data.theme.cdm-url }}/cdm/ref/collection/{{ site.data.theme.cdm-collection-id }}/id/' + feature.properties.cdm + '{% else %}{{ site.baseurl }}/items/' + feature.properties.id + '.html{% endif %}" ><img class="mapthumb" src="{{ site.data.theme.cdm-url }}/utils/getthumbnail/collection/{{ site.data.theme.cdm-collection-id }}/id/' + feature.properties.cdm + '" /></a>' +
+            '</h3><p><a class="btn btn-light" href="{% if site.data.theme.repo-link %}{{ site.data.theme.cdm-url }}/cdm/ref/collection/{{ site.data.theme.cdm-collection-id }}/id/' + feature.properties.cdm + '{% else %}{{ site.baseurl }}/items/' + feature.properties.id + '.html{% endif %}" ><img class="mapthumb" src="{{ site.data.theme.cdm-url }}/utils/getthumbnail/collection/{{ site.data.theme.cdm-collection-id }}/id/' + feature.properties.cdm + '" /></a>' +
             {% for f in fields %}{% if f.display %}
             '<br><strong>{{ f.display }}:</strong> ' + feature.properties.{{ f.field }} + {% endif %}{% endfor %}
-            '<br><a target="_blank" class="btn btn-light" href="{% if site.data.theme.repo-link %}{{ site.data.theme.cdm-url }}/cdm/ref/collection/{{ site.data.theme.cdm-collection-id }}/id/' + feature.properties.cdm + '{% else %}{{ site.baseurl }}/items/' + feature.properties.id + '.html{% endif %}" >View Item</a></p>');
+            '<br><a class="btn btn-light" href="{% if site.data.theme.repo-link %}{{ site.data.theme.cdm-url }}/cdm/ref/collection/{{ site.data.theme.cdm-collection-id }}/id/' + feature.properties.cdm + '{% else %}{{ site.baseurl }}/items/' + feature.properties.id + '.html{% endif %}" >View Item</a></p>');
             return marker;
         }, 
         onEachFeature: function (feature, layer) {

--- a/_includes/nav-search-cdm.html
+++ b/_includes/nav-search-cdm.html
@@ -5,6 +5,6 @@
     }
 </script>
 <form class="form-inline my-2 my-lg-0" role="search" id="search" onsubmit="cdm_search(); return false;">
-    <input id="nav-search" class="form-control mr-sm-2" type="text" placeholder="Search" aria-label="Search">
-    <button class="btn btn-pride-gold my-2 my-sm-0" type="submit">Search</button>
+    <input id="nav-search" class="form-control mr-sm-2 col-sm-9" type="text" placeholder="Search" aria-label="Search">
+    <button class="btn btn-pride-gold my-2 my-sm-0" type="submit"><i class="fas fa-search"></i></button>
 </form>

--- a/_includes/nav-search-site.html
+++ b/_includes/nav-search-site.html
@@ -10,7 +10,7 @@
         <div class="input-group-append">
             <button class="btn btn-light" type="submit">
                 <span id="search-icon"><svg viewBox="0 0 1024 974" height="16px" width="20px"><path d="M960 832L710.875 582.875C746.438 524.812 768 457.156 768 384 768 171.96900000000005 596 0 384 0 171.969 0 0 171.96900000000005 0 384c0 212 171.969 384 384 384 73.156 0 140.812-21.562 198.875-57L832 960c17.5 17.5 46.5 17.375 64 0l64-64C977.5 878.5 977.5 849.5 960 832zM384 640c-141.375 0-256-114.625-256-256s114.625-256 256-256 256 114.625 256 256S525.375 640 384 640z"/></svg></span>
-                <span class="sr-only">Search</span>
+                <span class="sr-only"><i class="fas fa-search"></i></span>
             </button>
         </div>
     </div>

--- a/_layouts/browse.html
+++ b/_layouts/browse.html
@@ -37,7 +37,7 @@ layout: page
                 </p>
                 {%- unless item.format contains 'image' -%}
                 <p>
-                    <a target="_blank" href="{% include item-link.html %}"><img class="thumb lazyload" data-original="{% include image/thumb.html %}" alt="item thumbnail"></a>
+                    <a href="{% include item-link.html %}"><img class="thumb lazyload" data-original="{% include image/thumb.html %}" alt="item thumbnail"></a>
                 </p>
                 {%- endunless -%}
                 <p>

--- a/_layouts/item.html
+++ b/_layouts/item.html
@@ -43,11 +43,11 @@ gallery: true
                 </div>
                 {%- endif -%}
                 <div class="text-center my-2">
-                    <a href="{% include download/item.html %}" target="_blank" class="btn btn-outline-clearwater" title="Object download">Download {{ page.format | split: '/' | last | upcase }}</a>
+                    <a href="{% include download/item.html %}" class="btn btn-outline-clearwater" title="Object download">Download {{ page.format | split: '/' | last | upcase }}</a>
                     {% if page.date %}{%- capture year -%}{% if page.date contains "-" %}{{ page.date | split: "-" | first }}{% elsif page.date contains "/" %}{{ page.date | split: "/" | last }}{% else %}{{ page.date }}{% endif %}{%- endcapture -%}
-                    <a href="{{ year | strip | prepend: '/timeline.html#' | relative_url }}" target="_blank" class="ml-2 btn btn-outline-clearwater" title="View object year on timeline">View on Timeline</a>{% endif %}
+                    <a href="{{ year | strip | prepend: '/timeline.html#' | relative_url }}" class="ml-2 btn btn-outline-clearwater" title="View object year on timeline">View on Timeline</a>{% endif %}
                     {% if page.latitude and page.longitude %}
-                    <a href="{{ '/map.html#' | append: page.latitude  | append: ',' | append: page.longitude | relative_url}}" rel="noopener" target="_blank" class="ml-2 btn btn-outline-clearwater" title="View object location on Google map">View on Map</a>{% endif %}
+                    <a href="{{ '/map.html#' | append: page.latitude  | append: ',' | append: page.longitude | relative_url}}" rel="noopener" class="ml-2 btn btn-outline-clearwater" title="View object location on Google map">View on Map</a>{% endif %}
                 </div>
             </div>
         </div>
@@ -74,20 +74,8 @@ gallery: true
     </div>
 
     <div class="row">
-        <div class="col-md-3">
-            <div class="card mb-2">
-                <div class="card-header">Related Items</div>
-                <div class="card-body">
-                    {% assign facets = page.subject | split: ";" %}
-                    <p>
-                    {% for f in facets %}
-                        <a class="btn btn-sm btn-secondary m-1" href="{{ f | strip | url_param_escape | prepend: '/browse.html#' | relative_url }}">{{ f }}</a> 
-                    {% endfor %}
-                    </p>
-                </div>
-            </div>
-        </div>
-        <div class="col-md-4">
+        
+        <div class="col-md-5">
             <div class="card mb-2">
                 <div class="card-header">Source</div>
                 <div class="card-body">
@@ -100,7 +88,7 @@ gallery: true
                 </div>
             </div>
         </div>
-        <div class="col-md-5">
+        <div class="col-md-6">
             <div class="card mb-2">
                 <div class="card-header">Rights</div>
                 <div class="card-body">


### PR DESCRIPTION
btn light == looked dirty
layout for mobile needed some adjustment on home page and other pages so I added a col to the image div 
removed the "target="_blank" throughout to keep the experience on mobile better (not tabs!) when staying within the collection
added a font awesome icon to the search button rather than "search" -- could be persauded to go another route

